### PR TITLE
Fix Stream API Domain

### DIFF
--- a/tutum/container.go
+++ b/tutum/container.go
@@ -145,7 +145,7 @@ Loop:
 func (self *Container) Run(command string, c chan Exec) {
 
 	endpoint := "container/" + self.Uuid + "/exec/?user=" + User + "&token=" + ApiKey + "&command=" + url.QueryEscape(command)
-	url := "wss://stream.tutum.co:443/v1/" + endpoint
+	url := StreamUrl + endpoint
 
 	header := http.Header{}
 	header.Add("User-Agent", customUserAgent)

--- a/tutum/container.go
+++ b/tutum/container.go
@@ -145,7 +145,7 @@ Loop:
 func (self *Container) Run(command string, c chan Exec) {
 
 	endpoint := "container/" + self.Uuid + "/exec/?user=" + User + "&token=" + ApiKey + "&command=" + url.QueryEscape(command)
-	url := "wss://live-test.tutum.co:443/v1/" + endpoint
+	url := "wss://stream.tutum.co:443/v1/" + endpoint
 
 	header := http.Header{}
 	header.Add("User-Agent", customUserAgent)


### PR DESCRIPTION
When trying to connect to the Stream API to run a command in a container, the SDK tries to connect to `live-test.tutum.co`, which doesn't exist and fails to resolve. This fixes that URL to point to the correct domain `stream.tutum.co` .
